### PR TITLE
fix: let CORS preflight pass

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -37,7 +37,7 @@ from utils.auth import check_api_key, many_hashes
 from utils.my_auth import async_token_auth
 from utils.permissions import OnlyAdminCanModify, OwnerOrAdminCanModify, \
     NotSilentOrAdminCanPost, AdminOrReadOnly, \
-    AdminOrPostOnly, OwenerOrAdminCanSee, AdminOnly
+    AdminOrPostOnly, OwenerOrAdminCanSee, AdminOnly, IsAuthenticatedEx
 from ws.utils import async_send_websocket_message_to_group
 
 
@@ -62,7 +62,7 @@ def login(request):
 
 
 @api_view(["GET"])
-@permission_classes([IsAuthenticated])
+@permission_classes([IsAuthenticatedEx])
 def logout(request):
     request.auth.delete()
     Token.objects.create(user=request.user)
@@ -226,7 +226,7 @@ class EmailApi(APIView):
 
 
 class DivisionsApi(APIView):
-    permission_classes = [IsAuthenticated, AdminOrReadOnly]
+    permission_classes = [IsAuthenticatedEx, AdminOrReadOnly]
 
     def get(self, request, **kwargs):
         division_id = kwargs.get('division_id')
@@ -253,7 +253,7 @@ class DivisionsApi(APIView):
 
 
 class HolesApi(APIView):
-    permission_classes = [IsAuthenticated, NotSilentOrAdminCanPost, OnlyAdminCanModify]
+    permission_classes = [IsAuthenticatedEx, NotSilentOrAdminCanPost, OnlyAdminCanModify]
 
     def get(self, request, **kwargs):
         # 校验数据
@@ -352,7 +352,7 @@ class HolesApi(APIView):
 
 
 class FloorsApi(APIView):
-    permission_classes = [IsAuthenticated, NotSilentOrAdminCanPost, OwnerOrAdminCanModify]
+    permission_classes = [IsAuthenticatedEx, NotSilentOrAdminCanPost, OwnerOrAdminCanModify]
 
     def get(self, request, **kwargs):
         # 获取单个
@@ -474,7 +474,7 @@ class FloorsApi(APIView):
 
 
 class TagsApi(APIView):
-    permission_classes = [IsAuthenticated, AdminOrReadOnly]
+    permission_classes = [IsAuthenticatedEx, AdminOrReadOnly]
 
     def get(self, request, **kwargs):
         # 获取单个
@@ -515,7 +515,7 @@ class TagsApi(APIView):
 
 
 class FavoritesApi(APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticatedEx]
 
     def get(self, request):
         query_set = request.user.favorites.all()
@@ -554,7 +554,7 @@ class FavoritesApi(APIView):
 
 
 class ReportsApi(APIView):
-    permission_classes = [IsAuthenticated, AdminOrPostOnly]
+    permission_classes = [IsAuthenticatedEx, AdminOrPostOnly]
 
     def post(self, request):
         floor_id = request.data.get('floor_id')
@@ -632,7 +632,7 @@ class ReportsApi(APIView):
 
 
 class MessagesApi(APIView):
-    permission_classes = [IsAuthenticated, OwnerOrAdminCanModify, OwenerOrAdminCanSee]
+    permission_classes = [IsAuthenticatedEx, OwnerOrAdminCanModify, OwenerOrAdminCanSee]
 
     def post(self, request):
         floor = get_object_or_404(Floor, pk=request.data.get('to'))
@@ -694,7 +694,7 @@ class MessagesApi(APIView):
 
 
 class UsersApi(APIView):
-    permission_classes = [IsAuthenticated, OwnerOrAdminCanModify, OwenerOrAdminCanSee]
+    permission_classes = [IsAuthenticatedEx, OwnerOrAdminCanModify, OwenerOrAdminCanSee]
 
     def get(self, request, **kwargs):
         user_id = kwargs.get('user_id')
@@ -737,7 +737,7 @@ class UsersApi(APIView):
 
 
 class PushTokensAPI(APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticatedEx]
 
     def get(self, request):
         if not request.user.is_admin:
@@ -821,7 +821,7 @@ class PenaltyApi(APIView):
 
 
 @api_view(["GET"])
-@permission_classes([IsAuthenticated])
+@permission_classes([IsAuthenticatedEx])
 def get_active_user(request):
     serializer = ActiveUserSerializer(data=request.query_params)
     serializer.is_valid(raise_exception=True)

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -4,6 +4,7 @@ from rest_framework.permissions import SAFE_METHODS
 
 # PATCH 方法不检查权限！！！
 MODIFY_METHODS = ('PUT', 'DELETE')
+CORS_METHODS = ('OPTIONS',)
 
 
 class OnlyAdminCanModify(permissions.BasePermission):
@@ -72,3 +73,16 @@ class OwnerOrAdminCanModify(permissions.BasePermission):
             return owner == request.user or request.user.is_admin
         else:
             return True
+
+
+class IsAuthenticatedEx(permissions.BasePermission):
+    """
+    Allows access only to authenticated users.
+    But also allows CORS preflight, i.e. OPTIONS.
+    """
+
+    def has_permission(self, request, view):
+        if request.method in CORS_METHODS:
+            return True
+        else:
+            return bool(request.user and request.user.is_authenticated)


### PR DESCRIPTION
We should endure `OPTIONS` requests to any endpoints as a CORS preflight, or it will not work at all.

**This patch has passed in the local test.**

**Note:** this single PR will NOT make the backend fully open to any requests. You still need to configure about it in the code, or in the gateway to respond with certain headers.