### PR TITLE
fix: forget to convert type in /reports

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -573,8 +573,8 @@ class ReportsApi(APIView):
         return Response(serializer.data, 201)
 
     def get(self, request, **kwargs):
-        start_report = request.query_params.get('start_report', 0)
-        length = request.query_params.get('length', 0)
+        start_report = int(request.query_params.get('start_report', '0'))
+        length = int(request.query_params.get('length', '0'))
         # 获取单个
         report_id = kwargs.get('report_id')
         if report_id:


### PR DESCRIPTION
`request.query_params.get` seems to return `str` only. It requires explicit conversion to `int`.

Please merge it into master branch if possible.