### PR TITLE
fix(danke): declare unique index with length for Teacher.Name

### DIFF
--- a/danke/model/teacher.go
+++ b/danke/model/teacher.go
@@ -2,6 +2,6 @@ package model
 
 type Teacher struct {
 	ID           int            `json:"id"`
-	Name         string         `json:"name" gorm:"not null"` // 教师姓名
+	Name         string         `json:"name" gorm:"not null;uniqueIndex:uk_teacher_name,length:191"` // 教师姓名
 	CourseGroups []*CourseGroup `gorm:"many2many:teacher_course_groups;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 }


### PR DESCRIPTION
## Problem

`Teacher.Name` has no `type`/`size` tag, so GORM maps it to `longtext` on MySQL. If the column already has a full-column `UNIQUE` index from an earlier migration, AutoMigrate crash-loops the service:

```
Error 1170 (42000): BLOB/TEXT column 'name' used in key specification without a key length
ALTER TABLE `teacher` MODIFY COLUMN `name` longtext NOT NULL
```

MySQL disallows a full-column index on a BLOB/TEXT column.

## Fix
Declare the unique index in the tag with an explicit prefix length.

- 191 is the utf8mb4-safe single-column prefix length, consistent with `CourseGroup.Code` which already uses the `length:` option.

Verified on an affected production DB: after applying the equivalent DDL, the service starts cleanly and AutoMigrate is a no-op on subsequent restarts.